### PR TITLE
chore(mark): remove election from `localStorage`

### DIFF
--- a/apps/mark/frontend/src/apimachine_config.test.tsx
+++ b/apps/mark/frontend/src/apimachine_config.test.tsx
@@ -6,10 +6,7 @@ import { electionFamousNames2021Fixtures } from '@votingworks/fixtures';
 import { render, screen } from '../test/react_testing_library';
 import { ApiMock, createApiMock } from '../test/helpers/mock_api_client';
 import { App } from './app';
-import {
-  setElectionInStorage,
-  setStateInStorage,
-} from '../test/helpers/election';
+import { setStateInStorage } from '../test/helpers/election';
 
 let apiMock: ApiMock;
 
@@ -18,7 +15,6 @@ beforeEach(() => {
   window.location.href = '/';
   apiMock = createApiMock();
   apiMock.expectGetSystemSettings();
-  apiMock.expectGetElectionDefinition(null);
 });
 
 afterEach(() => {
@@ -30,8 +26,7 @@ test('machineConfig is fetched from api client by default', async () => {
     codeVersion: 'fake-code-version',
   });
   const storage = new MemoryStorage();
-  await setElectionInStorage(
-    storage,
+  apiMock.expectGetElectionDefinition(
     electionFamousNames2021Fixtures.electionDefinition
   );
   await setStateInStorage(storage);

--- a/apps/mark/frontend/src/app.test.tsx
+++ b/apps/mark/frontend/src/app.test.tsx
@@ -10,10 +10,7 @@ import * as React from 'react';
 import { electionSampleDefinition } from '@votingworks/fixtures';
 import userEvent from '@testing-library/user-event';
 import { fireEvent, screen, waitFor } from '../test/react_testing_library';
-import {
-  setElectionInStorage,
-  setStateInStorage,
-} from '../test/helpers/election';
+import { setStateInStorage } from '../test/helpers/election';
 import { fakeTts } from '../test/helpers/fake_tts';
 import { advanceTimersAndPromises } from '../test/helpers/timers';
 import { render } from '../test/test_utils';
@@ -130,23 +127,22 @@ it('changes screen reader settings based on keyboard inputs', async () => {
 // This test is only really here to provide coverage for the default value for
 // `App`'s `reload` prop.
 it('uses window.location.reload by default', async () => {
+  const electionDefinition = electionSampleDefinition;
   // Stub location in a way that's good enough for this test, but not good
   // enough for general `window.location` use.
   const reload = jest.fn();
   apiMock.expectGetMachineConfig();
   apiMock.expectGetSystemSettings();
-  apiMock.expectGetElectionDefinition(null);
+  apiMock.expectGetElectionDefinition(electionDefinition);
   jest.spyOn(window, 'location', 'get').mockReturnValue({
     ...window.location,
     reload,
   });
 
   // Set up in an already-configured state.
-  const electionDefinition = electionSampleDefinition;
   const hardware = MemoryHardware.buildStandard();
   const storage = new MemoryStorage();
 
-  await setElectionInStorage(storage, electionDefinition);
   await setStateInStorage(storage, {
     appPrecinct: ALL_PRECINCTS_SELECTION,
     pollsState: 'polls_closed_initial',

--- a/apps/mark/frontend/src/app_card_unhappy_paths.test.tsx
+++ b/apps/mark/frontend/src/app_card_unhappy_paths.test.tsx
@@ -6,7 +6,7 @@ import { App } from './app';
 import { advanceTimersAndPromises } from '../test/helpers/timers';
 
 import {
-  setElectionInStorage,
+  electionDefinition,
   setStateInStorage,
 } from '../test/helpers/election';
 import { ApiMock, createApiMock } from '../test/helpers/mock_api_client';
@@ -18,7 +18,6 @@ beforeEach(() => {
   window.location.href = '/';
   apiMock = createApiMock();
   apiMock.expectGetSystemSettings();
-  apiMock.expectGetElectionDefinition(null);
 });
 
 afterEach(() => {
@@ -29,8 +28,7 @@ test('Shows card backwards screen when card connection error occurs', async () =
   const hardware = MemoryHardware.buildStandard();
   const storage = new MemoryStorage();
   apiMock.expectGetMachineConfig();
-
-  await setElectionInStorage(storage);
+  apiMock.expectGetElectionDefinition(electionDefinition);
   await setStateInStorage(storage);
 
   render(
@@ -42,7 +40,7 @@ test('Shows card backwards screen when card connection error occurs', async () =
     />
   );
   await advanceTimersAndPromises();
-  screen.getByText('Insert Card');
+  await screen.findByText('Insert Card');
 
   apiMock.setAuthStatus({
     status: 'logged_out',

--- a/apps/mark/frontend/src/app_cardless_voting.test.tsx
+++ b/apps/mark/frontend/src/app_cardless_voting.test.tsx
@@ -15,7 +15,6 @@ import { App } from './app';
 
 import {
   presidentContest,
-  setElectionInStorage,
   setStateInStorage,
   voterContests,
 } from '../test/helpers/election';
@@ -256,9 +255,8 @@ test('Another Voter submits blank ballot and clicks Done', async () => {
   const storage = new MemoryStorage();
   apiMock.expectGetMachineConfig();
   apiMock.expectGetSystemSettings();
-  apiMock.expectGetElectionDefinition(null);
+  apiMock.expectGetElectionDefinition(electionSampleDefinition);
 
-  await setElectionInStorage(storage, electionSampleDefinition);
   await setStateInStorage(storage);
 
   render(

--- a/apps/mark/frontend/src/app_contest_candidate_no_party.test.tsx
+++ b/apps/mark/frontend/src/app_contest_candidate_no_party.test.tsx
@@ -13,7 +13,6 @@ import { App } from './app';
 import { advanceTimersAndPromises } from '../test/helpers/timers';
 
 import { setStateInStorage } from '../test/helpers/election';
-import { electionStorageKey } from './app_root';
 import { ApiMock, createApiMock } from '../test/helpers/mock_api_client';
 
 let apiMock: ApiMock;
@@ -42,7 +41,6 @@ beforeEach(() => {
   window.location.href = '/';
   apiMock = createApiMock();
   apiMock.expectGetSystemSettings();
-  apiMock.expectGetElectionDefinition(null);
 });
 
 afterEach(() => {
@@ -56,8 +54,7 @@ it('Single Seat Contest', async () => {
   const storage = new MemoryStorage();
   apiMock.expectGetMachineConfig();
 
-  await storage.set(
-    electionStorageKey,
+  apiMock.expectGetElectionDefinition(
     asElectionDefinition(electionWithNoPartyCandidateContests)
   );
   await setStateInStorage(storage);

--- a/apps/mark/frontend/src/app_contest_ms_either_neither.test.tsx
+++ b/apps/mark/frontend/src/app_contest_ms_either_neither.test.tsx
@@ -29,10 +29,7 @@ import { render as renderWithBallotContext } from '../test/test_utils';
 import { withMarkup } from '../test/helpers/with_markup';
 import { advanceTimersAndPromises } from '../test/helpers/timers';
 
-import {
-  setElectionInStorage,
-  setStateInStorage,
-} from '../test/helpers/election';
+import { setStateInStorage } from '../test/helpers/election';
 import { ApiMock, createApiMock } from '../test/helpers/mock_api_client';
 
 let apiMock: ApiMock;
@@ -208,9 +205,8 @@ test('Can vote on a Mississippi Either Neither Contest', async () => {
   const storage = new MemoryStorage();
   apiMock.expectGetMachineConfig();
   apiMock.expectGetSystemSettings();
-  apiMock.expectGetElectionDefinition(null);
+  apiMock.expectGetElectionDefinition(electionDefinition);
 
-  await setElectionInStorage(storage, electionDefinition);
   await setStateInStorage(storage, {
     appPrecinct: singlePrecinctSelectionFor(precinctId),
   });

--- a/apps/mark/frontend/src/app_contest_multi_seat.test.tsx
+++ b/apps/mark/frontend/src/app_contest_multi_seat.test.tsx
@@ -9,7 +9,7 @@ import { advanceTimersAndPromises } from '../test/helpers/timers';
 
 import {
   countyCommissionersContest,
-  setElectionInStorage,
+  electionDefinition,
   setStateInStorage,
 } from '../test/helpers/election';
 import { ApiMock, createApiMock } from '../test/helpers/mock_api_client';
@@ -21,7 +21,6 @@ beforeEach(() => {
   window.location.href = '/';
   apiMock = createApiMock();
   apiMock.expectGetSystemSettings();
-  apiMock.expectGetElectionDefinition(null);
 });
 
 afterEach(() => {
@@ -35,7 +34,7 @@ it('Single Seat Contest', async () => {
   const storage = new MemoryStorage();
   apiMock.expectGetMachineConfig();
 
-  await setElectionInStorage(storage);
+  apiMock.expectGetElectionDefinition(electionDefinition);
   await setStateInStorage(storage);
 
   const { container } = render(

--- a/apps/mark/frontend/src/app_contest_single_seat.test.tsx
+++ b/apps/mark/frontend/src/app_contest_single_seat.test.tsx
@@ -8,8 +8,8 @@ import { App } from './app';
 import { advanceTimersAndPromises } from '../test/helpers/timers';
 
 import {
+  electionDefinition,
   presidentContest,
-  setElectionInStorage,
   setStateInStorage,
 } from '../test/helpers/election';
 import { ApiMock, createApiMock } from '../test/helpers/mock_api_client';
@@ -21,7 +21,6 @@ beforeEach(() => {
   window.location.href = '/';
   apiMock = createApiMock();
   apiMock.expectGetSystemSettings();
-  apiMock.expectGetElectionDefinition(null);
 });
 
 afterEach(() => {
@@ -35,7 +34,7 @@ it('Single Seat Contest', async () => {
   const hardware = MemoryHardware.buildStandard();
   const storage = new MemoryStorage();
 
-  await setElectionInStorage(storage);
+  apiMock.expectGetElectionDefinition(electionDefinition);
   await setStateInStorage(storage);
 
   const { container } = render(

--- a/apps/mark/frontend/src/app_contest_write_in.test.tsx
+++ b/apps/mark/frontend/src/app_contest_write_in.test.tsx
@@ -18,8 +18,8 @@ import {
 
 import {
   singleSeatContestWithWriteIn,
-  setElectionInStorage,
   setStateInStorage,
+  electionDefinition,
 } from '../test/helpers/election';
 import { ApiMock, createApiMock } from '../test/helpers/mock_api_client';
 import { hackActuallyCleanUpReactModal } from '../test/test_utils';
@@ -31,7 +31,6 @@ beforeEach(() => {
   window.location.href = '/';
   apiMock = createApiMock();
   apiMock.expectGetSystemSettings();
-  apiMock.expectGetElectionDefinition(null);
 });
 
 afterEach(() => {
@@ -43,9 +42,9 @@ it('Single Seat Contest with Write In', async () => {
 
   const hardware = MemoryHardware.buildStandard();
   const storage = new MemoryStorage();
+  apiMock.expectGetElectionDefinition(electionDefinition);
   apiMock.expectGetMachineConfig();
 
-  await setElectionInStorage(storage);
   await setStateInStorage(storage);
 
   const { container } = render(

--- a/apps/mark/frontend/src/app_contest_yes_no.test.tsx
+++ b/apps/mark/frontend/src/app_contest_yes_no.test.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { electionSample } from '@votingworks/fixtures';
 import { MemoryStorage, MemoryHardware } from '@votingworks/utils';
 
 import { getContestDistrictName } from '@votingworks/types';
@@ -18,8 +17,8 @@ import { withMarkup } from '../test/helpers/with_markup';
 import { advanceTimersAndPromises } from '../test/helpers/timers';
 
 import {
+  electionDefinition,
   measure102Contest,
-  setElectionInStorage,
   setStateInStorage,
 } from '../test/helpers/election';
 import { ApiMock, createApiMock } from '../test/helpers/mock_api_client';
@@ -31,7 +30,6 @@ beforeEach(() => {
   window.location.href = '/';
   apiMock = createApiMock();
   apiMock.expectGetSystemSettings();
-  apiMock.expectGetElectionDefinition(null);
 });
 
 afterEach(() => {
@@ -44,9 +42,9 @@ it('Single Seat Contest', async () => {
   const hardware = MemoryHardware.buildStandard();
   const storage = new MemoryStorage();
 
-  await setElectionInStorage(storage);
-  await setStateInStorage(storage);
+  apiMock.expectGetElectionDefinition(electionDefinition);
   apiMock.expectGetMachineConfig();
+  await setStateInStorage(storage);
 
   render(
     <App
@@ -124,7 +122,7 @@ it('Single Seat Contest', async () => {
   }
 
   const reviewTitle = getByTextWithMarkup(
-    `${getContestDistrictName(electionSample, measure102Contest)}${
+    `${getContestDistrictName(electionDefinition.election, measure102Contest)}${
       measure102Contest.title
     }`
   );

--- a/apps/mark/frontend/src/app_data.test.tsx
+++ b/apps/mark/frontend/src/app_data.test.tsx
@@ -1,10 +1,8 @@
 import { screen } from '../test/react_testing_library';
 
-import { electionStorageKey } from './app_root';
-
 import {
   election,
-  setElectionInStorage,
+  electionDefinition,
   setStateInStorage,
 } from '../test/helpers/election';
 import { advanceTimersAndPromises } from '../test/helpers/timers';
@@ -19,7 +17,6 @@ beforeEach(() => {
   apiMock = createApiMock();
   apiMock.expectGetMachineConfig();
   apiMock.expectGetSystemSettings();
-  apiMock.expectGetElectionDefinition(null);
 });
 
 afterEach(() => {
@@ -28,6 +25,7 @@ afterEach(() => {
 
 describe('loads election', () => {
   it('Machine is not configured by default', async () => {
+    apiMock.expectGetElectionDefinition(null);
     const { renderApp } = buildApp(apiMock);
     renderApp();
 
@@ -37,9 +35,9 @@ describe('loads election', () => {
     screen.getByText('VxMark is Not Configured');
   });
 
-  it('from storage', async () => {
+  it('from API', async () => {
     const { storage, renderApp } = buildApp(apiMock);
-    await setElectionInStorage(storage);
+    apiMock.expectGetElectionDefinition(electionDefinition);
     await setStateInStorage(storage);
     renderApp();
 
@@ -47,6 +45,5 @@ describe('loads election', () => {
     await advanceTimersAndPromises();
 
     screen.getByText(election.title);
-    expect(storage.get(electionStorageKey)).toBeTruthy();
   });
 });

--- a/apps/mark/frontend/src/app_polls_flows.test.tsx
+++ b/apps/mark/frontend/src/app_polls_flows.test.tsx
@@ -3,10 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { electionSampleDefinition } from '@votingworks/fixtures';
 import { LogEventId } from '@votingworks/logging';
 import { screen, within } from '../test/react_testing_library';
-import {
-  setElectionInStorage,
-  setStateInStorage,
-} from '../test/helpers/election';
+import { setStateInStorage } from '../test/helpers/election';
 import { buildApp } from '../test/helpers/build_app';
 import { ApiMock, createApiMock } from '../test/helpers/mock_api_client';
 import { hackActuallyCleanUpReactModal } from '../test/test_utils';
@@ -19,7 +16,6 @@ beforeEach(() => {
   apiMock = createApiMock();
   apiMock.expectGetMachineConfig();
   apiMock.expectGetSystemSettings();
-  apiMock.expectGetElectionDefinition(null);
 });
 
 afterEach(() => {
@@ -32,9 +28,8 @@ test('full polls flow', async () => {
   apiMock = createApiMock();
   apiMock.expectGetMachineConfig();
   apiMock.expectGetSystemSettings();
-  apiMock.expectGetElectionDefinition(null);
+  apiMock.expectGetElectionDefinition(electionSampleDefinition);
   const { renderApp, storage, logger } = buildApp(apiMock);
-  await setElectionInStorage(storage, electionSampleDefinition);
   await setStateInStorage(storage, { pollsState: 'polls_closed_initial' });
   renderApp();
   await screen.findByText('Polls Closed');
@@ -98,7 +93,7 @@ test('full polls flow', async () => {
 
 test('can close from paused', async () => {
   const { renderApp, storage } = buildApp(apiMock);
-  await setElectionInStorage(storage, electionSampleDefinition);
+  apiMock.expectGetElectionDefinition(electionSampleDefinition);
   await setStateInStorage(storage, { pollsState: 'polls_paused' });
   renderApp();
   await screen.findByText('Voting Paused');
@@ -116,7 +111,7 @@ test('can close from paused', async () => {
 
 test('no buttons to change polls from closed final', async () => {
   const { renderApp, storage } = buildApp(apiMock);
-  await setElectionInStorage(storage, electionSampleDefinition);
+  apiMock.expectGetElectionDefinition(electionSampleDefinition);
   await setStateInStorage(storage, { pollsState: 'polls_closed_final' });
   renderApp();
   await screen.findByText('Polls Closed');
@@ -137,7 +132,7 @@ test('no buttons to change polls from closed final', async () => {
 
 test('can reset polls to paused with system administrator card', async () => {
   const { renderApp, storage } = buildApp(apiMock);
-  await setElectionInStorage(storage, electionSampleDefinition);
+  apiMock.expectGetElectionDefinition(electionSampleDefinition);
   await setStateInStorage(storage, { pollsState: 'polls_closed_final' });
   renderApp();
   await screen.findByText('Polls Closed');

--- a/apps/mark/frontend/src/app_quit_on_idle.test.tsx
+++ b/apps/mark/frontend/src/app_quit_on_idle.test.tsx
@@ -10,10 +10,7 @@ import { App } from './app';
 
 import { advanceTimersAndPromises } from '../test/helpers/timers';
 
-import {
-  setElectionInStorage,
-  setStateInStorage,
-} from '../test/helpers/election';
+import { setStateInStorage } from '../test/helpers/election';
 
 import {
   IDLE_RESET_TIMEOUT_SECONDS,
@@ -31,7 +28,6 @@ beforeEach(() => {
   window.kiosk = fakeKiosk();
   apiMock = createApiMock();
   apiMock.expectGetSystemSettings();
-  apiMock.expectGetElectionDefinition(null);
 });
 
 afterEach(() => {
@@ -48,7 +44,7 @@ test('Insert Card screen idle timeout to quit app', async () => {
     machineId: '0000',
   });
 
-  await setElectionInStorage(storage);
+  apiMock.expectGetElectionDefinition(electionSampleDefinition);
   await setStateInStorage(storage);
 
   render(
@@ -78,7 +74,7 @@ test('Voter idle timeout', async () => {
   const hardware = MemoryHardware.buildStandard();
   const storage = new MemoryStorage();
   apiMock.expectGetMachineConfig();
-  await setElectionInStorage(storage, electionDefinition);
+  apiMock.expectGetElectionDefinition(electionDefinition);
   await setStateInStorage(storage);
   render(
     <App

--- a/apps/mark/frontend/src/app_replace_election.test.tsx
+++ b/apps/mark/frontend/src/app_replace_election.test.tsx
@@ -7,10 +7,7 @@ import {
 import { FakeKiosk, fakeKiosk } from '@votingworks/test-utils';
 import { DEFAULT_SYSTEM_SETTINGS } from '@votingworks/types';
 import { screen } from '../test/react_testing_library';
-import {
-  setElectionInStorage,
-  setStateInStorage,
-} from '../test/helpers/election';
+import { setStateInStorage } from '../test/helpers/election';
 import { render } from '../test/test_utils';
 import { App } from './app';
 import { ApiMock, createApiMock } from '../test/helpers/mock_api_client';
@@ -36,12 +33,9 @@ test('app renders a notice when election hash on card does not match that of mac
   const hardware = MemoryHardware.buildStandard();
   const storage = new MemoryStorage();
   apiMock.expectGetMachineConfig();
-  // Set up an already-congfigured election
+  // Set up an already-configured election
   apiMock.expectGetSystemSettings(DEFAULT_SYSTEM_SETTINGS);
   apiMock.expectGetElectionDefinition(electionSampleDefinition);
-
-  // setup with typical election
-  await setElectionInStorage(storage);
   await setStateInStorage(storage);
 
   render(

--- a/apps/mark/frontend/src/app_setup_errors.test.tsx
+++ b/apps/mark/frontend/src/app_setup_errors.test.tsx
@@ -14,7 +14,6 @@ import { advanceTimersAndPromises } from '../test/helpers/timers';
 
 import {
   electionDefinition,
-  setElectionInStorage,
   setStateInStorage,
 } from '../test/helpers/election';
 import { withMarkup } from '../test/helpers/with_markup';
@@ -27,7 +26,6 @@ beforeEach(() => {
   window.location.href = '/';
   apiMock = createApiMock();
   apiMock.expectGetSystemSettings();
-  apiMock.expectGetElectionDefinition(null);
 });
 
 afterEach(() => {
@@ -45,7 +43,7 @@ describe('Displays setup warning messages and errors screens', () => {
     const hardware = MemoryHardware.buildStandard();
     hardware.setAccessibleControllerConnected(true);
 
-    await setElectionInStorage(storage);
+    apiMock.expectGetElectionDefinition(electionDefinition);
     await setStateInStorage(storage);
 
     render(
@@ -88,7 +86,7 @@ describe('Displays setup warning messages and errors screens', () => {
     apiMock.expectGetMachineConfig();
     const storage = new MemoryStorage();
     const hardware = MemoryHardware.buildStandard();
-    await setElectionInStorage(storage);
+    apiMock.expectGetElectionDefinition(electionDefinition);
     await setStateInStorage(storage);
 
     render(
@@ -125,7 +123,7 @@ describe('Displays setup warning messages and errors screens', () => {
     apiMock.expectGetMachineConfig();
     const storage = new MemoryStorage();
     const hardware = MemoryHardware.buildStandard();
-    await setElectionInStorage(storage);
+    apiMock.expectGetElectionDefinition(electionDefinition);
     await setStateInStorage(storage);
     render(
       <App
@@ -159,7 +157,7 @@ describe('Displays setup warning messages and errors screens', () => {
     apiMock.expectGetMachineConfig();
     const storage = new MemoryStorage();
     const hardware = MemoryHardware.buildStandard();
-    await setElectionInStorage(storage, electionDefinition);
+    apiMock.expectGetElectionDefinition(electionDefinition);
     await setStateInStorage(storage);
     render(
       <App
@@ -191,7 +189,7 @@ describe('Displays setup warning messages and errors screens', () => {
     apiMock.expectGetMachineConfig();
     const storage = new MemoryStorage();
     const hardware = MemoryHardware.buildStandard();
-    await setElectionInStorage(storage);
+    apiMock.expectGetElectionDefinition(electionDefinition);
     await setStateInStorage(storage);
     render(
       <App

--- a/apps/mark/frontend/src/app_test_mode.test.tsx
+++ b/apps/mark/frontend/src/app_test_mode.test.tsx
@@ -7,10 +7,7 @@ import {
 import { MemoryHardware, MemoryStorage } from '@votingworks/utils';
 import { render, screen, waitFor } from '../test/react_testing_library';
 
-import {
-  setElectionInStorage,
-  setStateInStorage,
-} from '../test/helpers/election';
+import { setStateInStorage } from '../test/helpers/election';
 import { ApiMock, createApiMock } from '../test/helpers/mock_api_client';
 import { App } from './app';
 
@@ -21,7 +18,6 @@ beforeEach(() => {
   window.location.href = '/';
   apiMock = createApiMock();
   apiMock.expectGetSystemSettings();
-  apiMock.expectGetElectionDefinition(null);
 });
 
 afterEach(() => {
@@ -36,7 +32,7 @@ it('Prompts to change from test mode to live mode on election day', async () => 
   const hardware = MemoryHardware.buildStandard();
   const storage = new MemoryStorage();
   apiMock.expectGetMachineConfig();
-  await setElectionInStorage(storage, electionDefinition);
+  apiMock.expectGetElectionDefinition(electionDefinition);
   await setStateInStorage(storage, {
     isLiveMode: false,
   });

--- a/apps/mark/frontend/src/lib/gamepad.test.tsx
+++ b/apps/mark/frontend/src/lib/gamepad.test.tsx
@@ -11,7 +11,7 @@ import {
   contest0candidate0,
   contest0candidate1,
   contest1candidate0,
-  setElectionInStorage,
+  electionDefinition,
   setStateInStorage,
 } from '../../test/helpers/election';
 
@@ -25,7 +25,6 @@ beforeEach(() => {
   window.location.href = '/';
   apiMock = createApiMock();
   apiMock.expectGetSystemSettings();
-  apiMock.expectGetElectionDefinition(null);
 });
 
 afterEach(() => {
@@ -36,8 +35,7 @@ it('gamepad controls work', async () => {
   const hardware = MemoryHardware.buildStandard();
   const storage = new MemoryStorage();
   apiMock.expectGetMachineConfig();
-
-  await setElectionInStorage(storage);
+  apiMock.expectGetElectionDefinition(electionDefinition);
   await setStateInStorage(storage);
 
   render(

--- a/apps/mark/frontend/src/pages/unconfigured_election_screen_wrapper.tsx
+++ b/apps/mark/frontend/src/pages/unconfigured_election_screen_wrapper.tsx
@@ -7,12 +7,10 @@ import {
   Screen,
   useExternalStateChangeListener,
 } from '@votingworks/ui';
-import { ElectionDefinition } from '@votingworks/types';
 import { configureBallotPackageFromUsb } from '../api';
 
 interface Props {
   usbDriveStatus: UsbDriveStatus;
-  updateElectionDefinition: (electionDefinition: ElectionDefinition) => void;
 }
 
 /**
@@ -20,17 +18,13 @@ interface Props {
  * with VxMark-specific logic (primarily calls to the VxMark backend)
  */
 export function UnconfiguredElectionScreenWrapper(props: Props): JSX.Element {
-  const { updateElectionDefinition, usbDriveStatus } = props;
+  const { usbDriveStatus } = props;
   const configureMutation = configureBallotPackageFromUsb.useMutation();
 
   useExternalStateChangeListener(usbDriveStatus, (newUsbDriveStatus) => {
     if (newUsbDriveStatus === 'mounted') {
       // Errors are passed to and handled by UnconfiguredElectionScreen
-      void configureMutation.mutateAsync().then((result) => {
-        if (result.isOk()) {
-          updateElectionDefinition(result.ok());
-        }
-      });
+      configureMutation.mutate();
     }
   });
 

--- a/apps/mark/frontend/test/helpers/election.ts
+++ b/apps/mark/frontend/test/helpers/election.ts
@@ -7,7 +7,7 @@ import {
 } from '@votingworks/types';
 import { singlePrecinctSelectionFor, Storage } from '@votingworks/utils';
 import { electionSampleDefinition } from '@votingworks/fixtures';
-import { electionStorageKey, State, stateStorageKey } from '../../src/app_root';
+import { State, stateStorageKey } from '../../src/app_root';
 
 export const electionDefinition = electionSampleDefinition;
 export const { election } = electionDefinition;
@@ -56,13 +56,6 @@ export const voterContests = getContests({
   ballotStyle,
   election,
 });
-
-export async function setElectionInStorage(
-  storage: Storage,
-  newElectionDefinition = electionDefinition
-): Promise<void> {
-  await storage.set(electionStorageKey, newElectionDefinition);
-}
 
 export async function setStateInStorage(
   storage: Storage,


### PR DESCRIPTION
## Overview
We should be using the backend as the data store for everything.

## Demo Video or Screenshot
```
tree ~/.config/kiosk-browser/data
/home/vx/.config/kiosk-browser/data
└── state.json

0 directories, 1 file
```

## Testing Plan
- [x] Automated
- [x] Manual testing of configure/unconfigure

## Checklist

- [ ] I have added [logging](https://github.com/votingworks/vxsuite/tree/main/libs/logging) where appropriate to any new user actions, system updates such as file reads or storage writes, or errors introduced.
<!-- for user-facing changes, non-user facing changes can remove or ignore the below items -->
- [ ] I have added a screenshot and/or video to this PR to demo the change
- [ ] I have added the "user_facing_change" label to this PR to automate an announcement in #machine-product-updates
