### PR TITLE
Set up config for heroku deploy of rave server

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: ROCKET_PORT=$PORT ./services/rave-server/target/release/rave-server

--- a/RustConfig
+++ b/RustConfig
@@ -1,0 +1,1 @@
+BUILD_PATH=services/rave-server


### PR DESCRIPTION
Ideally these would live in services/rave-server but this is functional for now. There are buildpacks you can link with the rust one I am using to specify a path to the Procfile with an env variable so that one is easy, but the rust buildpack only knows to look in the root for its RustConfig file which you need to specify the path for the Cargo.toml. Longer term you could easily fork the rust buildpack and modify it to solve that problem though. 

FYI that there are various ROCKET_ environment variables set in the heroku dashboard and the configuration using the rusk buildpack (https://github.com/emk/heroku-buildpack-rust) is there as well. 