### PR TITLE
feat(rave-mark): print the mailing label last

### DIFF
--- a/apps/rave-jx-terminal/frontend/public/styles.css
+++ b/apps/rave-jx-terminal/frontend/public/styles.css
@@ -550,16 +550,16 @@ video {
   margin-bottom: 1rem;
 }
 
+.mr-2 {
+  margin-right: 0.5rem;
+}
+
 .mt-4 {
   margin-top: 1rem;
 }
 
 .mt-8 {
   margin-top: 2rem;
-}
-
-.mr-2 {
-  margin-right: 0.5rem;
 }
 
 .block {
@@ -610,12 +610,12 @@ video {
   white-space: nowrap;
 }
 
-.rounded-md {
-  border-radius: 0.375rem;
-}
-
 .rounded-lg {
   border-radius: 0.5rem;
+}
+
+.rounded-md {
+  border-radius: 0.375rem;
 }
 
 .rounded-l-md {
@@ -656,6 +656,11 @@ video {
   background-color: rgb(253 186 116 / var(--tw-bg-opacity));
 }
 
+.bg-purple-500 {
+  --tw-bg-opacity: 1;
+  background-color: rgb(168 85 247 / var(--tw-bg-opacity));
+}
+
 .bg-red-300 {
   --tw-bg-opacity: 1;
   background-color: rgb(252 165 165 / var(--tw-bg-opacity));
@@ -666,11 +671,6 @@ video {
   background-color: rgb(253 224 71 / var(--tw-bg-opacity));
 }
 
-.bg-purple-500 {
-  --tw-bg-opacity: 1;
-  background-color: rgb(168 85 247 / var(--tw-bg-opacity));
-}
-
 .p-1 {
   padding: 0.25rem;
 }
@@ -679,12 +679,12 @@ video {
   padding: 0.5rem;
 }
 
-.p-8 {
-  padding: 2rem;
-}
-
 .p-3 {
   padding: 0.75rem;
+}
+
+.p-8 {
+  padding: 2rem;
 }
 
 .px-4 {

--- a/apps/rave-mark/frontend/src/screens/voting/already_voted_screen.tsx
+++ b/apps/rave-mark/frontend/src/screens/voting/already_voted_screen.tsx
@@ -1,0 +1,15 @@
+import { H2, Main, Screen, Text } from '@votingworks/ui';
+
+export function AlreadyVotedScreen(): JSX.Element {
+  return (
+    <Screen>
+      <Main centerChild padded>
+        <H2>You’ve Already Voted</H2>
+        <Text center small>
+          If you haven’t already done so, please mail your paper ballot using
+          the provided envelope and personalized mailing label.
+        </Text>
+      </Main>
+    </Screen>
+  );
+}

--- a/apps/rave-mark/frontend/src/screens/voting/index.tsx
+++ b/apps/rave-mark/frontend/src/screens/voting/index.tsx
@@ -1,5 +1,6 @@
-export * from './done_screen';
+export * from './already_voted_screen';
 export * from './mark_screen';
+export * from './post_vote_screen';
 export * from './print_ballot_screen';
 export * from './print_mailing_label_screen';
 export * from './review_mark_screen';

--- a/apps/rave-mark/frontend/src/screens/voting/post_vote_screen.tsx
+++ b/apps/rave-mark/frontend/src/screens/voting/post_vote_screen.tsx
@@ -1,9 +1,9 @@
 import { H2, Main, Screen, Text } from '@votingworks/ui';
 
-export function DoneScreen(): JSX.Element {
+export function PostVoteScreen(): JSX.Element {
   return (
     <Screen>
-      <Main centerChild>
+      <Main centerChild padded>
         <H2>Mail Your Paper Ballot</H2>
         <Text center small>
           Please mail your paper ballot to:
@@ -14,7 +14,7 @@ export function DoneScreen(): JSX.Element {
           Anytown, USA 12345
         </Text>
         <Text center small>
-          Remove your card when you&rsquo;re ready to end your voting session.
+          Remove your card when you’re ready to end your voting session.
         </Text>
       </Main>
     </Screen>

--- a/apps/rave-mark/frontend/src/screens/voting/submit_screen.tsx
+++ b/apps/rave-mark/frontend/src/screens/voting/submit_screen.tsx
@@ -1,7 +1,7 @@
 import { VotesDict } from '@votingworks/types';
 import {
   Button,
-  H1,
+  H2,
   Main,
   Modal,
   NumberPad,
@@ -92,14 +92,14 @@ export function SubmitScreen({
           themeDeprecated={fontSizeTheme.medium}
           maxWidth={false}
         >
-          <H1>Cast My Ballot</H1>
+          <H2>You’re Almost Done</H2>
           <P>
             Thanks for reviewing your printed ballot!
             <br />
-            Now, we&rsquo;ll sign and cast your electronic ballot.
+            Tap the button below to continue.
           </P>
           <Button variant="primary" onPress={() => setIsShowingPinModal(true)}>
-            Sign &amp; Cast My Ballot
+            Cast My Ballot
           </Button>
           {isShowingPinModal && (
             <Modal
@@ -127,9 +127,9 @@ export function SubmitScreen({
                     onPress={handleEnter}
                     disabled={isCheckingPin}
                   >
-                    {isCheckingPin ? 'Checking…' : 'Submit'}
+                    {isCheckingPin ? 'Checking…' : 'Cast My Ballot'}
                   </Button>
-                  <Button onPress={dismissPinModal}>Back</Button>
+                  <Button onPress={dismissPinModal}>Go Back</Button>
                 </React.Fragment>
               }
             />


### PR DESCRIPTION
## Overview

The mailing label will likely require data from the sign & cast operation, so this commit moves that step to the end. This change also allows us to more easily distinguish the "just voted" from "previously voted" states, so we can show more specific instructions for those cases.

Also:
- remove voter-facing mentions of "signing"
- use unicode instead of `&rsquo;`
- minor visual tweaks: `padded` and `H2` instead of `H1`

**Note:** there is a [known issue](https://votingworks.slack.com/archives/CEL6D3GAD/p1693956894994539) with this where the size of the `@page` is not respected for some subsequent print-to-PDF requests. I'm not sure why, but I'm going to merge this anyway since I plan to change the approach for building the label and I'd rather just land this first.

## Demo Video or Screenshot

https://github.com/votingworks/rave/assets/1938/474db357-2ea1-412c-947c-e5c4387b627a


## Testing Plan
Manual.
