### PR TITLE
build: install `cups-bsd` during setup

### DIFF
--- a/script/rave-setup
+++ b/script/rave-setup
@@ -23,6 +23,7 @@ setup-prereqs() {
   sudo apt-get install \
     build-essential \
     chromium \
+    cups-bsd \
     curl \
     git \
     libcairo2-dev \


### PR DESCRIPTION
## Overview
It provides the `lpr` command we use in `rave-mark`.

## Demo Video or Screenshot
n/a

## Testing Plan
Manual.
