### PR TITLE
feat(rave-mark): check PIN on registration

### DIFF
--- a/apps/rave-mark/frontend/jest.config.js
+++ b/apps/rave-mark/frontend/jest.config.js
@@ -13,6 +13,7 @@ module.exports = {
   transformIgnorePatterns: [
     '[/\\\\]node_modules[/\\\\].+\\.(js|jsx|mjs|cjs|ts|tsx)$',
   ],
+  setupFilesAfterEnv: ['<rootDir>/test/setup.ts'],
   coverageThreshold: {
     global: {
       statements: 0,

--- a/apps/rave-mark/frontend/package.json
+++ b/apps/rave-mark/frontend/package.json
@@ -55,12 +55,16 @@
     "styled-components": "^5.2.3"
   },
   "devDependencies": {
+    "@jest/types": "^29.6.1",
+    "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^12.1.5",
+    "@testing-library/user-event": "^13.5.0",
     "@types/jest": "^29.5.2",
     "@types/luxon": "^3.0.0",
     "@types/react": "18.2.18",
     "@types/react-dom": "^18.2.7",
     "@types/styled-components": "^5.1.9",
+    "@types/testing-library__jest-dom": "^5.14.9",
     "@typescript-eslint/eslint-plugin": "5.37.0",
     "@typescript-eslint/parser": "5.37.0",
     "@vitejs/plugin-react": "^1.3.2",

--- a/apps/rave-mark/frontend/src/components/pin_pad_modal.test.tsx
+++ b/apps/rave-mark/frontend/src/components/pin_pad_modal.test.tsx
@@ -1,0 +1,148 @@
+import { PinLength, renderWithThemes as render } from '@votingworks/ui';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { PinPadModal } from './pin_pad_modal';
+
+const pinLength = PinLength.exactly(8);
+
+test('shows errors if provided', async () => {
+  const onEnter = jest.fn();
+  const onDismiss = jest.fn();
+
+  const { rerender } = render(
+    <PinPadModal
+      pinLength={pinLength}
+      primaryButtonLabel="Enter"
+      dismissButtonLabel="Cancel"
+      onEnter={onEnter}
+      onDismiss={onDismiss}
+      error="Invalid PIN"
+    />
+  );
+
+  await screen.findByText('Error: Invalid PIN');
+
+  rerender(
+    <PinPadModal
+      pinLength={pinLength}
+      primaryButtonLabel="Enter"
+      dismissButtonLabel="Cancel"
+      onEnter={onEnter}
+      onDismiss={onDismiss}
+    />
+  );
+
+  expect(screen.queryByText(/Error:/)).not.toBeInTheDocument();
+});
+
+test('calls onEnter with the PIN when the enter button is pressed', async () => {
+  const onEnter = jest.fn();
+  const onDismiss = jest.fn();
+
+  render(
+    <PinPadModal
+      pinLength={pinLength}
+      primaryButtonLabel="Enter"
+      dismissButtonLabel="Cancel"
+      onEnter={onEnter}
+      onDismiss={onDismiss}
+    />
+  );
+
+  userEvent.click(await screen.findByRole('button', { name: 'enter' }));
+  expect(onEnter).toHaveBeenCalledWith('');
+
+  userEvent.click(screen.getByRole('button', { name: '1' }));
+  userEvent.click(screen.getByRole('button', { name: '2' }));
+  userEvent.click(screen.getByRole('button', { name: '3' }));
+  userEvent.click(screen.getByRole('button', { name: '4' }));
+
+  userEvent.click(await screen.findByRole('button', { name: 'enter' }));
+  expect(onEnter).toHaveBeenCalledWith('1234');
+});
+
+test('calls onDismiss when the dismiss button is pressed', async () => {
+  const onEnter = jest.fn();
+  const onDismiss = jest.fn();
+
+  render(
+    <PinPadModal
+      pinLength={pinLength}
+      primaryButtonLabel="Enter"
+      dismissButtonLabel="Cancel"
+      onEnter={onEnter}
+      onDismiss={onDismiss}
+    />
+  );
+
+  userEvent.click(await screen.findByRole('button', { name: 'cancel' }));
+  expect(onDismiss).toHaveBeenCalled();
+});
+
+test('displays the masked PIN', async () => {
+  const onEnter = jest.fn();
+  const onDismiss = jest.fn();
+
+  render(
+    <PinPadModal
+      pinLength={pinLength}
+      primaryButtonLabel="Enter"
+      dismissButtonLabel="Cancel"
+      onEnter={onEnter}
+      onDismiss={onDismiss}
+    />
+  );
+
+  userEvent.click(screen.getByRole('button', { name: '1' }));
+  userEvent.click(screen.getByRole('button', { name: '1' }));
+  userEvent.click(screen.getByRole('button', { name: '1' }));
+  userEvent.click(screen.getByRole('button', { name: '1' }));
+
+  await screen.findByText('• • • • - - - -');
+});
+
+test('clears the PIN when the clear button is pressed', async () => {
+  const onEnter = jest.fn();
+  const onDismiss = jest.fn();
+
+  render(
+    <PinPadModal
+      pinLength={pinLength}
+      primaryButtonLabel="Enter"
+      dismissButtonLabel="Cancel"
+      onEnter={onEnter}
+      onDismiss={onDismiss}
+    />
+  );
+
+  userEvent.click(screen.getByRole('button', { name: '1' }));
+  userEvent.click(screen.getByRole('button', { name: '2' }));
+  userEvent.click(screen.getByRole('button', { name: '3' }));
+  userEvent.click(screen.getByRole('button', { name: '4' }));
+  userEvent.click(screen.getByRole('button', { name: 'clear' }));
+
+  await screen.findByText('- - - - - - - -');
+});
+
+test('removes the last digit when the backspace button is pressed', async () => {
+  const onEnter = jest.fn();
+  const onDismiss = jest.fn();
+
+  render(
+    <PinPadModal
+      pinLength={pinLength}
+      primaryButtonLabel="Enter"
+      dismissButtonLabel="Cancel"
+      onEnter={onEnter}
+      onDismiss={onDismiss}
+    />
+  );
+
+  userEvent.click(screen.getByRole('button', { name: '1' }));
+  userEvent.click(screen.getByRole('button', { name: '2' }));
+  userEvent.click(screen.getByRole('button', { name: '3' }));
+  userEvent.click(screen.getByRole('button', { name: '4' }));
+  userEvent.click(screen.getByRole('button', { name: 'backspace' }));
+
+  await screen.findByText('• • • - - - - -');
+});

--- a/apps/rave-mark/frontend/src/components/pin_pad_modal.tsx
+++ b/apps/rave-mark/frontend/src/components/pin_pad_modal.tsx
@@ -1,0 +1,101 @@
+import {
+  Button,
+  Modal,
+  NumberPad,
+  PinLength,
+  Text,
+  usePinEntry,
+} from '@votingworks/ui';
+import React from 'react';
+import styled from 'styled-components';
+
+const NumberPadWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  margin-top: 10px;
+  font-size: 1em;
+  > div {
+    width: 400px;
+  }
+  *:focus {
+    outline: none;
+  }
+`;
+
+const EnteredCode = styled.div`
+  margin-top: 5px;
+  text-align: center;
+  font-family: monospace;
+  font-size: 1.5em;
+  font-weight: 600;
+`;
+
+export interface PinPadModalProps {
+  pinLength: PinLength;
+  primaryButtonLabel: string;
+  dismissButtonLabel: string;
+  onEnter: (pin: string) => void;
+  onDismiss: () => void;
+  title?: string;
+  disabled?: boolean;
+  error?: string;
+}
+
+export function PinPadModal({
+  pinLength,
+  primaryButtonLabel,
+  dismissButtonLabel,
+  onEnter,
+  onDismiss,
+  title = 'Enter Your PIN',
+  disabled,
+  error,
+}: PinPadModalProps): JSX.Element {
+  const pinEntry = usePinEntry({ pinLength });
+
+  function handleEnter() {
+    onEnter(pinEntry.current);
+  }
+
+  function dismissPinModal() {
+    pinEntry.reset();
+    onDismiss();
+  }
+
+  return (
+    <Modal
+      title={title}
+      onOverlayClick={dismissPinModal}
+      content={
+        <React.Fragment>
+          {error && <Text error>Error: {error}</Text>}
+          <EnteredCode>{pinEntry.display}</EnteredCode>
+          <NumberPadWrapper>
+            <NumberPad
+              disabled={disabled}
+              onButtonPress={pinEntry.handleDigit}
+              onBackspace={pinEntry.handleBackspace}
+              onClear={pinEntry.reset}
+              onEnter={handleEnter}
+            />
+          </NumberPadWrapper>
+        </React.Fragment>
+      }
+      actions={
+        <React.Fragment>
+          <Button
+            variant="primary"
+            onPress={handleEnter}
+            disabled={disabled}
+            aria-label="enter"
+          >
+            {primaryButtonLabel}
+          </Button>
+          <Button onPress={dismissPinModal} aria-label="cancel">
+            {dismissButtonLabel}
+          </Button>
+        </React.Fragment>
+      }
+    />
+  );
+}

--- a/apps/rave-mark/frontend/src/screens/voting/submit_screen.tsx
+++ b/apps/rave-mark/frontend/src/screens/voting/submit_screen.tsx
@@ -3,85 +3,50 @@ import {
   Button,
   H2,
   Main,
-  Modal,
-  NumberPad,
   P,
   Prose,
   Screen,
   fontSizeTheme,
-  usePinEntry,
 } from '@votingworks/ui';
-import React, { useState } from 'react';
-import styled from 'styled-components';
+import { useState } from 'react';
 import { castBallot } from '../../api';
+import { PinPadModal } from '../../components/pin_pad_modal';
 import { COMMON_ACCESS_CARD_PIN_LENGTH } from '../../globals';
-
-const NumberPadWrapper = styled.div`
-  display: flex;
-  justify-content: center;
-  margin-top: 10px;
-  font-size: 1em;
-  > div {
-    width: 400px;
-  }
-  *:focus {
-    outline: none;
-  }
-`;
-
-const EnteredCode = styled.div`
-  margin-top: 5px;
-  text-align: center;
-  font-family: monospace;
-  font-size: 1.5em;
-  font-weight: 600;
-`;
 
 export interface SubmitScreenProps {
   votes: VotesDict;
   onSubmitted: () => void;
 }
 
-const pinLength = COMMON_ACCESS_CARD_PIN_LENGTH;
-
 export function SubmitScreen({
   votes,
   onSubmitted,
 }: SubmitScreenProps): JSX.Element {
-  const [error, setError] = useState<string>();
+  const [pinError, setPinError] = useState<string>();
   const [isShowingPinModal, setIsShowingPinModal] = useState(false);
-  const [isCheckingPin, setIsCheckingPin] = useState(false);
-  const pinEntry = usePinEntry({ pinLength });
   const castBallotMutation = castBallot.useMutation();
   const castBallotMutationMutateAsync = castBallotMutation.mutateAsync;
+  const isCheckingPin = castBallotMutation.isLoading;
 
   async function submitBallot(pin: string) {
-    setError(undefined);
-    setIsCheckingPin(true);
+    setPinError(undefined);
     try {
       await castBallotMutationMutateAsync(
         { votes, pin },
         {
           onError(err) {
-            setError(err instanceof Error ? err.message : `${err}`);
+            setPinError(err instanceof Error ? err.message : `${err}`);
           },
         }
       );
       onSubmitted();
     } catch (err) {
-      setError(err instanceof Error ? err.message : `${err}`);
-    } finally {
-      setIsCheckingPin(false);
+      setPinError(err instanceof Error ? err.message : `${err}`);
     }
   }
 
-  async function handleEnter() {
-    await submitBallot(pinEntry.current);
-  }
-
-  function dismissPinModal() {
-    setIsShowingPinModal(false);
-    pinEntry.reset();
+  async function handleEnter(pin: string) {
+    await submitBallot(pin);
   }
 
   return (
@@ -102,36 +67,16 @@ export function SubmitScreen({
             Cast My Ballot
           </Button>
           {isShowingPinModal && (
-            <Modal
-              title="Enter Your PIN"
-              onOverlayClick={dismissPinModal}
-              content={
-                <React.Fragment>
-                  {error && <P>{error}</P>}
-                  <EnteredCode>{pinEntry.display}</EnteredCode>
-                  <NumberPadWrapper>
-                    <NumberPad
-                      disabled={isCheckingPin}
-                      onButtonPress={pinEntry.handleDigit}
-                      onBackspace={pinEntry.handleBackspace}
-                      onClear={pinEntry.reset}
-                      onEnter={handleEnter}
-                    />
-                  </NumberPadWrapper>
-                </React.Fragment>
+            <PinPadModal
+              pinLength={COMMON_ACCESS_CARD_PIN_LENGTH}
+              primaryButtonLabel={
+                isCheckingPin ? 'Checking…' : 'Cast My Ballot'
               }
-              actions={
-                <React.Fragment>
-                  <Button
-                    variant="primary"
-                    onPress={handleEnter}
-                    disabled={isCheckingPin}
-                  >
-                    {isCheckingPin ? 'Checking…' : 'Cast My Ballot'}
-                  </Button>
-                  <Button onPress={dismissPinModal}>Go Back</Button>
-                </React.Fragment>
-              }
+              dismissButtonLabel="Go Back"
+              onEnter={handleEnter}
+              onDismiss={() => setIsShowingPinModal(false)}
+              disabled={isCheckingPin}
+              error={pinError}
             />
           )}
         </Prose>

--- a/apps/rave-mark/frontend/test/setup.ts
+++ b/apps/rave-mark/frontend/test/setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/libs/auth/src/apdu.ts
+++ b/libs/auth/src/apdu.ts
@@ -51,6 +51,7 @@ export const STATUS_WORD = {
   SUCCESS_MORE_DATA_AVAILABLE: { SW1: 0x61 },
   FILE_NOT_FOUND: { SW1: 0x6a, SW2: 0x82 },
   VERIFY_FAIL: { SW1: 0x63 },
+  SECURITY_CONDITION_NOT_SATISFIED: { SW1: 0x69, SW2: 0x82 },
 } as const;
 
 /**

--- a/libs/auth/src/java_card.ts
+++ b/libs/auth/src/java_card.ts
@@ -29,6 +29,7 @@ import {
   GENERAL_AUTHENTICATE,
   GET_DATA,
   isIncorrectPinStatusWord,
+  isSecurityConditionNotSatisfiedStatusWord,
   numRemainingPinAttemptsFromIncorrectPinStatusWord,
   pivDataObjectId,
   PUT_DATA,
@@ -140,6 +141,17 @@ export class JavaCard implements Card {
           numIncorrectPinAttempts,
         };
       }
+
+      if (
+        error instanceof ResponseApduError &&
+        isSecurityConditionNotSatisfiedStatusWord(error.statusWord())
+      ) {
+        return {
+          response: 'incorrect',
+          numIncorrectPinAttempts: MAX_NUM_INCORRECT_PIN_ATTEMPTS,
+        };
+      }
+
       throw error;
     }
     if (this.cardStatus.status === 'ready' && this.cardStatus.cardDetails) {

--- a/libs/auth/src/piv.ts
+++ b/libs/auth/src/piv.ts
@@ -76,6 +76,21 @@ export function isIncorrectPinStatusWord(statusWord: [Byte, Byte]): boolean {
 }
 
 /**
+ * CAC cards respond to the VERIFY command with a status word of 0x6982 when the
+ * PIN is incorrect.
+ */
+export function isSecurityConditionNotSatisfiedStatusWord(
+  statusWord: [Byte, Byte]
+): boolean {
+  const [sw1, sw2] = statusWord;
+
+  return (
+    sw1 === STATUS_WORD.SECURITY_CONDITION_NOT_SATISFIED.SW1 &&
+    sw2 === STATUS_WORD.SECURITY_CONDITION_NOT_SATISFIED.SW2
+  );
+}
+
+/**
  * See isIncorrectPinStatusWord().
  */
 export function numRemainingPinAttemptsFromIncorrectPinStatusWord(

--- a/libs/basics/src/errors.test.ts
+++ b/libs/basics/src/errors.test.ts
@@ -8,6 +8,7 @@ test.each<{ error: unknown; expectedErrorMessage: string }>([
   { error: Buffer.from('Whoa!', 'utf-8'), expectedErrorMessage: 'Whoa!' },
   { error: 1234, expectedErrorMessage: '1234' },
   { error: { error: 'Whoa!' }, expectedErrorMessage: '[object Object]' },
+  { error: { message: 'Whoa!' }, expectedErrorMessage: 'Whoa!' },
 ])('extractErrorMessage', ({ error, expectedErrorMessage }) => {
   expect(extractErrorMessage(error)).toEqual(expectedErrorMessage);
 });

--- a/libs/basics/src/errors.ts
+++ b/libs/basics/src/errors.ts
@@ -4,6 +4,11 @@
 export function extractErrorMessage(error: unknown): string {
   return error instanceof Error
     ? error.message
+    : typeof error === 'object' &&
+      error !== null &&
+      'message' in error &&
+      typeof (error as { message?: unknown }).message === 'string'
+    ? (error as { message: string }).message
     : error &&
       typeof error === 'object' &&
       'toString' in (error as { toString(): string })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -339,9 +339,18 @@ importers:
         specifier: ^5.2.3
         version: 5.3.11(react-dom@18.2.0)(react-is@18.2.0)(react@18.2.0)
     devDependencies:
+      '@jest/types':
+        specifier: ^29.6.1
+        version: 29.6.1
+      '@testing-library/jest-dom':
+        specifier: ^5.17.0
+        version: 5.17.0
       '@testing-library/react':
         specifier: ^12.1.5
         version: 12.1.5(react-dom@18.2.0)(react@18.2.0)
+      '@testing-library/user-event':
+        specifier: ^13.5.0
+        version: 13.5.0(@testing-library/dom@9.3.1)
       '@types/jest':
         specifier: ^29.5.2
         version: 29.5.3
@@ -357,6 +366,9 @@ importers:
       '@types/styled-components':
         specifier: ^5.1.9
         version: 5.1.26
+      '@types/testing-library__jest-dom':
+        specifier: ^5.14.9
+        version: 5.14.9
       '@typescript-eslint/eslint-plugin':
         specifier: 5.37.0
         version: 5.37.0(@typescript-eslint/parser@5.37.0)(eslint@8.23.1)(typescript@4.6.3)


### PR DESCRIPTION
## Overview
When we moved the PIN check to the end of the voting flow we lost the PIN check for registration. This adds that back at the end on submit, just like with voting. We don't use it to sign anything yet, but that'll come later.

## Demo Video or Screenshot

https://github.com/votingworks/rave/assets/1938/3188c3a0-7d86-4e61-a773-433c155abadf


## Testing Plan
Manual, but with an automated test for the new `PinPadModal`.
