### PR TITLE
feat(rave-mark): add more sync status to Admin dashboard

### DIFF
--- a/apps/rave-mark/backend/src/app.ts
+++ b/apps/rave-mark/backend/src/app.ts
@@ -340,8 +340,11 @@ function buildApi({
       void raveServerClient.sync({ authStatus });
     },
 
-    getServerSyncAttempts() {
-      return workspace.store.getServerSyncAttempts();
+    getServerSyncStatus() {
+      return {
+        attempts: workspace.store.getServerSyncAttempts(),
+        status: workspace.store.getSyncStatus(),
+      };
     },
 
     logOut() {

--- a/apps/rave-mark/backend/src/rave_server_client.ts
+++ b/apps/rave-mark/backend/src/rave_server_client.ts
@@ -255,7 +255,32 @@ export class RaveServerClientImpl {
         ),
       });
 
-      debug('created or replaced ballot %s', ballotId);
+      debug('created or replaced printed ballot %s', ballotId);
+    }
+
+    for (const scannedBallot of output.scannedBallots) {
+      const localElection = this.store.getElection({
+        serverId: scannedBallot.electionId,
+      });
+
+      assert(
+        localElection,
+        `could not find local election with server id ${scannedBallot.electionId}`
+      );
+
+      const ballotId = this.store.createScannedBallot({
+        id:
+          scannedBallot.machineId === VX_MACHINE_ID
+            ? scannedBallot.clientId
+            : ClientId(),
+        serverId: scannedBallot.serverId,
+        clientId: scannedBallot.clientId,
+        machineId: scannedBallot.machineId,
+        electionId: localElection.id,
+        castVoteRecord: scannedBallot.castVoteRecord,
+      });
+
+      debug('created or replaced scanned ballot %s', ballotId);
     }
   }
 

--- a/apps/rave-mark/frontend/src/api.ts
+++ b/apps/rave-mark/frontend/src/api.ts
@@ -146,13 +146,13 @@ export const sync = {
   },
 } as const;
 
-export const getServerSyncAttempts = {
+export const getServerSyncStatus = {
   queryKey(): QueryKey {
-    return ['getServerSyncAttempts'];
+    return ['getServerSyncStatus'];
   },
   useQuery() {
     const apiClient = useApiClient();
-    return useQuery(this.queryKey(), () => apiClient.getServerSyncAttempts(), {
+    return useQuery(this.queryKey(), () => apiClient.getServerSyncStatus(), {
       staleTime: 0,
       refetchInterval: 1000,
     });

--- a/apps/rave-mark/frontend/src/screens/admin/dashboard_screen.tsx
+++ b/apps/rave-mark/frontend/src/screens/admin/dashboard_screen.tsx
@@ -1,30 +1,108 @@
-import { Button, H1, Main, P, Screen, Table, Text } from '@votingworks/ui';
+import {
+  Button,
+  H1,
+  H2,
+  Main,
+  Screen,
+  TD,
+  TH,
+  Table,
+  Text,
+} from '@votingworks/ui';
 import React from 'react';
-import { getServerSyncAttempts, sync } from '../../api';
+import styled from 'styled-components';
+import { format } from '@votingworks/utils';
+import { getServerSyncStatus, sync } from '../../api';
 
 export interface DashboardScreenProps {
   onClickShowVoterFlow: () => void;
 }
 
+const FloatingTopRight = styled.div`
+  position: absolute;
+  top: 0;
+  right: 0;
+  padding: 1rem;
+  display: flex;
+  flex-direction: row;
+  gap: 1rem;
+`;
+
 export function DashboardScreen({
   onClickShowVoterFlow,
 }: DashboardScreenProps): JSX.Element {
   const syncMutation = sync.useMutation();
-  const getServerSyncAttemptsQuery = getServerSyncAttempts.useQuery();
+  const getServerSyncStatusQuery = getServerSyncStatus.useQuery();
 
   return (
     <Screen>
       <Main>
         <H1>Admin</H1>
-        <P>
-          <Button onPress={onClickShowVoterFlow}>Start voter flow</Button>
-        </P>
-        <Button
-          onPress={() => syncMutation.mutate()}
-          disabled={syncMutation.isLoading}
-        >
-          Sync with server
-        </Button>
+        <FloatingTopRight>
+          <Button onPress={onClickShowVoterFlow} variant="previous">
+            Exit to Voter Flow
+          </Button>
+          <Button
+            onPress={() => syncMutation.mutate()}
+            disabled={syncMutation.isLoading}
+          >
+            Start Sync Manually
+          </Button>
+        </FloatingTopRight>
+
+        <H2>Sync Status</H2>
+        <Table>
+          <thead>
+            <tr>
+              <TH>Type</TH>
+              <TH>Synced with Server</TH>
+              <TH>Pending Sync to Server</TH>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <TD>Ballots Cast</TD>
+              <TD>
+                {format.count(
+                  getServerSyncStatusQuery.data?.status.printedBallots.synced ??
+                    0
+                )}
+              </TD>
+              <TD>
+                {format.count(
+                  getServerSyncStatusQuery.data?.status.printedBallots
+                    .pending ?? 0
+                )}
+              </TD>
+            </tr>
+            <tr>
+              <TD>Registration Requests</TD>
+              <TD>
+                {format.count(
+                  getServerSyncStatusQuery.data?.status.pendingRegistrations
+                    .synced ?? 0
+                )}
+              </TD>
+              <TD>
+                {format.count(
+                  getServerSyncStatusQuery.data?.status.pendingRegistrations
+                    .pending ?? 0
+                )}
+              </TD>
+            </tr>
+            <tr>
+              <TD>Elections</TD>
+              <TD>
+                {format.count(
+                  getServerSyncStatusQuery.data?.status.elections.synced ?? 0
+                )}
+              </TD>
+              <TD>n/a</TD>
+            </tr>
+          </tbody>
+        </Table>
+
+        <H2>Sync History</H2>
         <Table>
           <thead>
             <tr>
@@ -35,7 +113,7 @@ export function DashboardScreen({
             </tr>
           </thead>
           <tbody>
-            {getServerSyncAttemptsQuery.data?.map((attempt) => (
+            {getServerSyncStatusQuery.data?.attempts.map((attempt) => (
               <tr key={attempt.id}>
                 <td>{attempt.creator}</td>
                 <td>


### PR DESCRIPTION
## Overview
Adds synced/pending count table to the Admin dashboard. Also fixes a couple issues:
- admin lookup was incorrect (swapped CAC ID & machine ID)
- scanned ballots were not being persisted in the mark DB

## Demo Video or Screenshot
<img width="1675" alt="image" src="https://github.com/votingworks/rave/assets/1938/c3124219-27cf-4271-b9ba-77dc530a2c4d">

## Testing Plan
Manually tested with my sample CAC card made into an admin user.
