### PR TITLE
fix(mark): increase size of label address & QR code

### DIFF
--- a/apps/cacvote-mark/backend/src/mail-label/rendering/index.tsx
+++ b/apps/cacvote-mark/backend/src/mail-label/rendering/index.tsx
@@ -1,5 +1,6 @@
 import { Buffer } from 'buffer';
-import { writeFile } from 'fs/promises';
+import { readFile } from 'fs/promises';
+import { join } from 'path';
 import { chromium } from 'playwright';
 import React from 'react';
 import ReactDomServer from 'react-dom/server';
@@ -10,191 +11,94 @@ export const SIZE_INCHES = {
   height: 6,
 } as const;
 
-export const SIZE_POINTS = {
-  width: SIZE_INCHES.width * 96,
-  height: SIZE_INCHES.height * 96,
-} as const;
-
-export function buildSvg({
+export function build({
   mailingAddress,
   qrCodeData,
 }: {
   mailingAddress: string;
   qrCodeData: Uint8Array;
 }): JSX.Element {
-  const padding = {
-    x: 5.76,
-    y: 12.48,
-  } as const;
-  const inner = {
-    width: SIZE_POINTS.width - padding.x * 2,
-    height: SIZE_POINTS.height - padding.y * 2,
-  } as const;
-  const thickBorderSize = 4;
-  const mediumBorderSize = 3;
-
   const mailingAddressLines = mailingAddress.split('\n').map((l) => l.trim());
 
   return (
-    <svg width={SIZE_POINTS.width} height={SIZE_POINTS.height}>
-      <g transform={`translate(${padding.x}, ${padding.y})`}>
-        <svg width={inner.width} height={inner.height}>
-          <rect
-            x={2}
-            y={2}
-            width={inner.width - thickBorderSize}
-            height={inner.height - thickBorderSize}
-            fill="white"
-            stroke="black"
-            strokeWidth={thickBorderSize}
-          />
-          <line
-            x1={0}
-            y1={83.52}
-            x2={inner.width - thickBorderSize}
-            y2={83.52}
-            stroke="black"
-            strokeWidth={mediumBorderSize}
-          />
-          <line
-            x1={0}
-            y1={'4in'}
-            x2={inner.width - thickBorderSize}
-            y2={'4in'}
-            stroke="black"
-            strokeWidth={mediumBorderSize}
-          />
-        </svg>
-        <g transform="translate(1, 2)">
-          <svg width={63} height={80}>
-            <text
-              x="50%"
-              y={73}
-              textAnchor="middle"
-              fontSize="92"
-              fontFamily="open-sans, sans-serif"
-              fill="white"
-              stroke="black"
-              strokeWidth={mediumBorderSize}
-            >
-              E
-            </text>
-          </svg>
-        </g>
-        <g transform="translate(64, 0)">
-          <line
-            x1={0}
-            y1={0}
-            x2={0}
-            y2={83.52}
-            stroke="black"
-            strokeWidth={mediumBorderSize}
-          />
-          <g transform="translate(9.6, 0)">
-            <text
-              x={0}
-              y={22.08}
-              dominantBaseline="middle"
-              fontSize={24}
-              fontFamily="open-sans, sans-serif"
-              fill="black"
-            >
-              Official
-            </text>
-            <text
-              x={0}
-              y={45.12}
-              dominantBaseline="middle"
-              fontSize={24}
-              fontFamily="open-sans, sans-serif"
-              fill="black"
-            >
-              Election
-            </text>
-            <text
-              x={0}
-              y={68.16}
-              dominantBaseline="middle"
-              fontSize={24}
-              fontFamily="open-sans, sans-serif"
-              fill="black"
-            >
-              Mail
-            </text>
-          </g>
-        </g>
-
-        {/* QR Code */}
-        <g transform="translate(270, 425)">
-          <QrCode data={qrCodeData} />
-        </g>
-
-        {/* USPS Priority Mail */}
-        <g transform="translate(0, 84)">
-          <svg width={inner.width} height={32}>
-            <text
-              x="50%"
-              y="50%"
-              dominantBaseline="middle"
-              textAnchor="middle"
-              fontSize={20}
-              fontFamily="open-sans, sans-serif"
-              fill="black"
-              fontWeight={600}
-            >
-              USPS PRIORITY MAIL®
-            </text>
-            <line
-              x1={0}
-              y1={28}
-              x2="100%"
-              y2={28}
-              stroke="black"
-              strokeWidth={mediumBorderSize}
-            />
-          </svg>
-        </g>
-
-        {/* Shipping Address */}
-        <g transform={`translate(12, ${84 + 35 + 39 + 13 + 55})`}>
-          <svg width={inner.width} height={96}>
-            <text
-              x={0}
-              y={0}
-              dominantBaseline="hanging"
-              fontSize={12}
-              fontFamily="open-sans, sans-serif"
-              fill="black"
-            >
-              Ship
-            </text>
-            <text
-              x={0}
-              y={11}
-              dominantBaseline="hanging"
-              fontSize={12}
-              fontFamily="open-sans, sans-serif"
-              fill="black"
-            >
-              to:
-            </text>
-            {mailingAddressLines.map((l, i) => (
-              <text
-                key={`line-${i}`}
-                x={55}
-                y={i * 16}
-                dominantBaseline="hanging"
-                fontSize={14}
-                fontFamily="open-sans, sans-serif"
-                fill="black"
-              >
-                {l}
-              </text>
-            ))}
-          </svg>
-        </g>
-      </g>
-    </svg>
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        border: '4px solid black',
+        width: `${SIZE_INCHES.width}in`,
+        height: `${SIZE_INCHES.height}in`,
+        fontFamily: 'Arial, sans-serif',
+      }}
+    >
+      <div
+        id="header"
+        style={{
+          display: 'flex',
+          flexDirection: 'row',
+          alignItems: 'center',
+          width: '100%',
+        }}
+      >
+        <div
+          style={{
+            fontSize: '6em',
+            WebkitTextStroke: '2px black',
+            color: 'white',
+            flexGrow: 0,
+            padding: '0 10px',
+            fontWeight: 'bold',
+          }}
+        >
+          E
+        </div>
+        <div style={{ fontSize: '1.3em' }}>
+          Official
+          <br />
+          Election
+          <br />
+          Mail
+        </div>
+      </div>
+      <div
+        id="content"
+        style={{
+          display: 'flex',
+          flexDirection: 'row',
+          flexGrow: 1,
+          alignItems: 'center',
+          alignContent: 'center',
+          borderTop: '4px solid black',
+          borderBottom: '4px solid black',
+          width: '100%',
+          padding: '3em',
+          gap: '2em',
+        }}
+      >
+        <div>
+          Ship
+          <br />
+          to:
+        </div>
+        <div style={{ flexDirection: 'column', fontSize: '1.4em' }}>
+          {mailingAddressLines.map((line, index) => (
+            <div key={index}>{line}</div>
+          ))}
+        </div>
+      </div>
+      <div
+        id="footer"
+        style={{
+          display: 'flex',
+          width: '100%',
+          justifyContent: 'end',
+          padding: '1em',
+        }}
+      >
+        <QrCode data={qrCodeData} />
+      </div>
+    </div>
   );
 }
 
@@ -229,15 +133,12 @@ export async function buildPdf({
   mailingAddress: string;
   qrCodeData: Uint8Array;
 }): Promise<Buffer> {
-  return await renderToPdf(buildSvg({ mailingAddress, qrCodeData }));
-}
-
-if (require.main === module) {
-  void (async () => {
-    const qrCodeData = Buffer.from('hello, world');
-    const mailingAddress = `VotingWorks\n123 Main St\nAnytown, USA 12345`;
-
-    const pdfBuffer = await buildPdf({ mailingAddress, qrCodeData });
-    await writeFile('mailing_label.pdf', pdfBuffer);
-  })();
+  return await renderToPdf(
+    <body>
+      <style>
+        {await readFile(join(__dirname, 'modern-normalize.css'), 'utf8')}
+      </style>
+      {build({ mailingAddress, qrCodeData })}
+    </body>
+  );
 }

--- a/apps/cacvote-mark/backend/src/mail-label/rendering/modern-normalize.css
+++ b/apps/cacvote-mark/backend/src/mail-label/rendering/modern-normalize.css
@@ -1,0 +1,201 @@
+/*! modern-normalize v3.0.1 | MIT License | https://github.com/sindresorhus/modern-normalize */
+
+/*
+Document
+========
+*/
+
+/**
+Use a better box model (opinionated).
+*/
+
+*,
+::before,
+::after {
+  box-sizing: border-box;
+}
+
+html {
+  /* Improve consistency of default fonts in all browsers. (https://github.com/sindresorhus/modern-normalize/issues/3) */
+  font-family: system-ui, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif,
+    'Apple Color Emoji', 'Segoe UI Emoji';
+  line-height: 1.15; /* 1. Correct the line height in all browsers. */
+  -webkit-text-size-adjust: 100%; /* 2. Prevent adjustments of font size after orientation changes in iOS. */
+  tab-size: 4; /* 3. Use a more readable tab size (opinionated). */
+}
+
+/*
+Sections
+========
+*/
+
+body {
+  margin: 0; /* Remove the margin in all browsers. */
+}
+
+/*
+Text-level semantics
+====================
+*/
+
+/**
+Add the correct font weight in Chrome and Safari.
+*/
+
+b,
+strong {
+  font-weight: bolder;
+}
+
+/**
+1. Improve consistency of default fonts in all browsers. (https://github.com/sindresorhus/modern-normalize/issues/3)
+2. Correct the odd 'em' font sizing in all browsers.
+*/
+
+code,
+kbd,
+samp,
+pre {
+  font-family: ui-monospace, SFMono-Regular, Consolas, 'Liberation Mono', Menlo,
+    monospace; /* 1 */
+  font-size: 1em; /* 2 */
+}
+
+/**
+Add the correct font size in all browsers.
+*/
+
+small {
+  font-size: 80%;
+}
+
+/**
+Prevent 'sub' and 'sup' elements from affecting the line height in all browsers.
+*/
+
+sub,
+sup {
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
+}
+
+sub {
+  bottom: -0.25em;
+}
+
+sup {
+  top: -0.5em;
+}
+
+/*
+Tabular data
+============
+*/
+
+/**
+Correct table border color inheritance in Chrome and Safari. (https://issues.chromium.org/issues/40615503, https://bugs.webkit.org/show_bug.cgi?id=195016)
+*/
+
+table {
+  border-color: currentcolor;
+}
+
+/*
+Forms
+=====
+*/
+
+/**
+1. Change the font styles in all browsers.
+2. Remove the margin in Firefox and Safari.
+*/
+
+button,
+input,
+optgroup,
+select,
+textarea {
+  font-family: inherit; /* 1 */
+  font-size: 100%; /* 1 */
+  line-height: 1.15; /* 1 */
+  margin: 0; /* 2 */
+}
+
+/**
+Correct the inability to style clickable types in iOS and Safari.
+*/
+
+button,
+[type='button'],
+[type='reset'],
+[type='submit'] {
+  -webkit-appearance: button;
+}
+
+/**
+Remove the padding so developers are not caught out when they zero out 'fieldset' elements in all browsers.
+*/
+
+legend {
+  padding: 0;
+}
+
+/**
+Add the correct vertical alignment in Chrome and Firefox.
+*/
+
+progress {
+  vertical-align: baseline;
+}
+
+/**
+Correct the cursor style of increment and decrement buttons in Safari.
+*/
+
+::-webkit-inner-spin-button,
+::-webkit-outer-spin-button {
+  height: auto;
+}
+
+/**
+1. Correct the odd appearance in Chrome and Safari.
+2. Correct the outline style in Safari.
+*/
+
+[type='search'] {
+  -webkit-appearance: textfield; /* 1 */
+  outline-offset: -2px; /* 2 */
+}
+
+/**
+Remove the inner padding in Chrome and Safari on macOS.
+*/
+
+::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+/**
+1. Correct the inability to style clickable types in iOS and Safari.
+2. Change font properties to 'inherit' in Safari.
+*/
+
+::-webkit-file-upload-button {
+  -webkit-appearance: button; /* 1 */
+  font: inherit; /* 2 */
+}
+
+/*
+Interactive
+===========
+*/
+
+/*
+Add the correct display in Chrome and Safari.
+*/
+
+summary {
+  display: list-item;
+}

--- a/apps/cacvote-mark/backend/src/mail-label/rendering/qrcode.tsx
+++ b/apps/cacvote-mark/backend/src/mail-label/rendering/qrcode.tsx
@@ -1,6 +1,11 @@
-import { integers } from '@votingworks/basics';
 import React from 'react';
 import { qrcodegen } from './qrcodegen';
+
+/**
+ * The Nippon thermal label printer can print 8 dots per millimeter, and
+ * https://www.qrcode.com/en/howto/cell.html recommends using 0.5mm for that density.
+ */
+const MIN_MODULE_SIZE_MM = 0.5;
 
 export function QrCode({ data }: { data: Uint8Array }): JSX.Element {
   const encoded = qrcodegen.QrCode.encodeBinary(
@@ -8,31 +13,31 @@ export function QrCode({ data }: { data: Uint8Array }): JSX.Element {
     qrcodegen.QrCode.Ecc.MEDIUM
   );
 
-  const constrainingSize = 87.5;
-  const moduleSize = 20;
-  const scale = constrainingSize / encoded.size / moduleSize;
+  const goOrigin = 'M 0 0 ';
+  const drawSquare = 'h 1 v 1 h -1 z ';
+  const goNextColumn = 'm 1 0 ';
+  const goNextRow = `m ${-encoded.size} 1 `;
+
+  let d = goOrigin;
+  for (let y = 0; y < encoded.size; y += 1) {
+    for (let x = 0; x < encoded.size; x += 1) {
+      if (encoded.getModule(x, y)) {
+        d += drawSquare;
+      }
+      d += goNextColumn;
+    }
+    d += goNextRow;
+  }
 
   return (
-    <svg width={100} height={87.5}>
-      {[
-        ...integers()
-          .take(encoded.size)
-          .flatMap((y) =>
-            integers()
-              .take(encoded.size)
-              .map((x) => (
-                <rect
-                  key={`${x},${y}`}
-                  x={x * moduleSize}
-                  y={y * moduleSize}
-                  width={moduleSize}
-                  height={moduleSize}
-                  fill={encoded.getModule(x, y) ? 'black' : 'white'}
-                  transform={`scale(${scale})`}
-                />
-              ))
-          ),
-      ]}
+    <svg
+      // set the viewBox to the module size of the QR code
+      viewBox={`0 0 ${encoded.size} ${encoded.size}`}
+      // set the width and height to the desired physical size of the QR code in millimeters
+      width={`${encoded.size * MIN_MODULE_SIZE_MM}mm`}
+      height={`${encoded.size * MIN_MODULE_SIZE_MM}mm`}
+    >
+      <path d={d} fill="black" />
     </svg>
   );
 }


### PR DESCRIPTION

## Overview

This change redoes the rendering to use HTML+flexbox instead of SVG except for the QR code, which I also reworked to use a single `<path>` element which avoids the small gaps between modules that using `<rect>` produced.

## Demo Video or Screenshot

| Before | After |
|-|-|
|![CleanShot 2025-04-03 at 11 23 26@2x](https://github.com/user-attachments/assets/4bb4760e-8040-4503-b2a6-95a6db8fc62c)|![CleanShot 2025-04-03 at 11 23 31@2x](https://github.com/user-attachments/assets/b4f7b525-c2b1-4fb3-a906-7209adf001ef)|

| `<rect>`-based QR code | `<path>`-based QR code |
|-|-|
|![CleanShot 2025-04-03 at 11 24 17@2x](https://github.com/user-attachments/assets/e0a7a003-5ac3-4ab6-a818-173f23131d86)|![CleanShot 2025-04-03 at 11 26 11@2x](https://github.com/user-attachments/assets/838a28ed-efec-4251-abad-652a37239af8)|

## Testing Plan

Tested manually using `./bin/test-print-mail-label --printer mock` as I refined it, then tested printing a real label:
![IMG_9167](https://github.com/user-attachments/assets/4daa302e-a1dc-43d2-9e45-0d13be57acd4)
